### PR TITLE
now passes size and metaData when using putObjects

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -156,7 +156,7 @@ module.exports = function (RED) {
 
                     // ====  PUT OBJECT  ===================================================
                 case "putObject":
-                    minioClient.putObject(opParams.bucketName, opParams.objectName, opParams.stream, function (err, etag) {
+                    minioClient.putObject(opParams.bucketName, opParams.objectName, opParams.stream, opParams.size, opParams.metaData, function (err, etag) {
                         if (err) {
                             helpers.statusUpdate(node, "red", "dot", 'Error', 5000);
                             node.error = err;

--- a/objects.js
+++ b/objects.js
@@ -156,7 +156,7 @@ module.exports = function (RED) {
 
                     // ====  PUT OBJECT  ===================================================
                 case "putObject":
-                    minioClient.putObject(opParams.bucketName, opParams.objectName, opParams.stream, opParams.size, opParams.metaData, function (err, etag) {
+                    minioClient.putObject(opParams.bucketName, opParams.objectName, opParams.stream, opParams.metaData, function (err, etag) {
                         if (err) {
                             helpers.statusUpdate(node, "red", "dot", 'Error', 5000);
                             node.error = err;


### PR DESCRIPTION
Edited the function call to now also pass the size and the metaData as the node description says. Also checked the function call with the underlying minio javascript library https://docs.min.io/docs/javascript-client-api-reference.html